### PR TITLE
Changes done to rectify the activity timestamp bash file to remove -i…

### DIFF
--- a/scripts/Execute-get_all_users_activity_timestamp_csvs.sh
+++ b/scripts/Execute-get_all_users_activity_timestamp_csvs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+echo "Script started"
 # Variable definations
 day_of_week=$(date +%A);  # (0..6); 0 is Sunday, 5 is Friday
 day_of_month=$(date +%d); # (1-28 for Feb and 1-30 / 1-31 for the other months); day 
@@ -8,11 +8,11 @@ sleeping_time="10m";
 
 # If 2nd and 4th Friday trigger the script inside docker container (after sleeping time to give enough time to start container and services inside it). 
 # Else pint date and necessary variables.  
-if ([ ${day_of_week} == "Friday" -a ${day_of_month} -ge 1 -a ${day_of_month} -le 14 ] || [ ${day_of_week} == "Sunday" -a ${month} == "February" -a ${day_of_month} -ge 22 -a ${day_of_month} -le 28 ] || [ ${day_of_week} == "Sunday" -a ${month} != "February" -a ${day_of_month} -ge 25 -a ${day_of_month} -le 31 ]); then # || [ ${day_of_week} == "Sunday" -a ${day_of_month} -ge 22 -a ${day_of_month} -le 28 ] || []); then
+if ([ ${day_of_week} == "Friday" -a ${day_of_month} -ge 1 -a ${day_of_month} -le 14 ] || [ ${day_of_week} == "Friday" -a ${month} == "February" -a ${day_of_month} -ge 22 -a ${day_of_month} -le 28 ] || [ ${day_of_week} == "Friday" -a ${month} != "February" -a ${day_of_month} -ge 25 -a ${day_of_month} -le 31 ]); then # || [ ${day_of_week} == "Sunday" -a ${day_of_month} -ge 22 -a ${day_of_month} -le 28 ] || []); then
     echo "Trigger script (Before sleeping : '$(date)') {Sleeping time: ${sleeping_time}in}";    
     sleep ${sleeping_time};
     echo "Trigger script (Before sleeping : '$(date)') {Sleeping time: ${sleeping_time}in}";    
-    docker exec -it gstudio /bin/sh -c "echo \"execfile('/home/docker/code/gstudio/doc/deployer/get_all_users_activity_timestamp_csvs.py')\" |/usr/bin/python /home/docker/code/gstudio/gnowsys-ndf/manage.py shell";
+    docker exec gstudio /bin/sh -c "echo \"execfile('/home/docker/code/gstudio/doc/deployer/get_all_users_activity_timestamp_csvs.py')\" |/usr/bin/python /home/docker/code/gstudio/gnowsys-ndf/manage.py shell";
 else
     echo "Script not Triggered (Date: '$(date)') : ${day_of_week} : ${month} : ${day_of_month} :";
 fi

--- a/scripts/backup-old-server-data.sh
+++ b/scripts/backup-old-server-data.sh
@@ -60,7 +60,7 @@ function backup_completely() {
     for (( i=1; i<5; i++ )); 
     do
 
-          check_disk=`lsblk | grep sdb9 | wc -l`
+          check_disk=`lsblk | grep /mnt | wc -l`
 
           if [[ "$check_disk" != "1" ]]; then
                 sleep 5;


### PR DESCRIPTION
**Changes done so that activity timestamp csvs get generated as well as the back up file to remove the hardcoding of disk**
---
- Issue 1   : Activity timestamp python script is not getting triggered as a result no corresponding csvs got 
                   generated
   + Fix      : Have removed the inline options -it from the Execute- 
                   get_all_users_activity_timestamp_csvs.sh file.
- Issue 2   : On full backup of server, if any pen drive is connected then the process exits with message 
                  "Please re-insert". 
    + Fix     : In backup-old-server-data.sh , there is a if condition which expects the external HDD to be 
                    always mounted in `sdb9`. Hence changed the condition to match with `\mnt` instead.